### PR TITLE
Optimized ev3c motor command sending to reuse a file stream.

### DIFF
--- a/ev3c_motor.h
+++ b/ev3c_motor.h
@@ -114,6 +114,7 @@ typedef struct ev3_motor_struct
 	int32_t ramp_up_sp_fd;
 	int32_t ramp_down_sp_fd;
 	int32_t time_sp_fd;
+	FILE* command_stream;
 	ev3_string commands[16];
 	int32_t command_count;
 	ev3_string stop_commands[16];


### PR DESCRIPTION
Instead of opening a new file descriptor each time a command is sent to the motor, I've optimized the library to reuse a single FILE* stream for sending commands to the motor driver. This results in an over 10x performance speed up on an EV3 brick (~1500 commands per second to ~18000 commands per second).